### PR TITLE
fix issue: Transition length is limited to screen width

### DIFF
--- a/src/grouploop-1.0.3.js
+++ b/src/grouploop-1.0.3.js
@@ -27,7 +27,7 @@ Repository: https://github.com/scottalguire/grouploop
       var el = this;
       var windowWidth = $(window).width() < 768 ? $(window).width() * 2 : $(window).width();
       var v = settings.velocity; // velocity
-      var wrapperWidth = $(window).width() < 768 ? $(el).width() * 2 : $(el).width();
+      var wrapperWidth = $(window).width() < 768 ? $(el).width() * $(el).find(settings.childNode).length : $(el).width();
       var firstItem = $(el)
         .find(settings.childWrapper + " " + settings.childNode)
         .first();
@@ -147,7 +147,7 @@ Repository: https://github.com/scottalguire/grouploop
             curXPos = -windowWidth;
           }
         } else {
-          if (curXPos >= -windowWidth) {
+          if (curXPos >= -wrapperWidth) {
             curXPos = curXPos - 1 * v;
             $(el)
               .find(settings.childWrapper)


### PR DESCRIPTION
The childWrapper width calculating wrong and ends up with windowWidth. I recalculate the width of childWrapper as width of grouped elements